### PR TITLE
Disable python 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,14 +38,6 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
-    - TARGET_ARCH: x86
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: true            # [win and py>35]
   features:
     - vc9               # [win and py27]
     - vc10              # [win and py34]


### PR DESCRIPTION
Since py35 and py36 both use the same vc version, it's not necessary
to build boost-cpp in both versions. This disables py36 builds.

cc @jschueller 