### PR TITLE
Remove Python headers

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,6 +23,10 @@ set /p MAJ_MIN_VER=<temp.txt
 move %LIBRARY_INC%\boost-%MAJ_MIN_VER%\boost %LIBRARY_INC%
 if errorlevel 1 exit 1
 
+:: Remove Python headers as we don't build Boost.Python.
+del %LIBRARY_INC%\boost\python.hpp
+rmdir /s /q %LIBRARY_INC%\boost\python
+
 :: Move dll's to LIBRARY_BIN
 move %LIBRARY_LIB%\*vc%VS_MAJOR%0-mt-%MAJ_MIN_VER%.dll "%LIBRARY_BIN%"
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -46,3 +46,6 @@ LINKFLAGS="${LINKFLAGS} -L${LIBRARY_PATH}"
     -j"${CPU_COUNT}" \
     install | tee b2.log 2>&1
 
+# Remove Python headers as we don't build Boost.Python.
+rm "${PREFIX}/include/boost/python.hpp"
+rm -r "${PREFIX}/include/boost/python"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,12 @@ requirements:
 
 test:
   commands:
+    # Verify Python headers are removed.
+    - "! test -f $PREFIX/lib/python.hpp"                         # [unix]
+    - "! test -d $PREFIX/lib/python"                             # [unix]
+    - if exist %PREFIX%\\Library\\include\\python.hpp exit 1     # [win]
+    - if exist %PREFIX%\\Library\\include\\python exit 1         # [win]
+
     # Verify static-only libraries.
     - test -f $PREFIX/lib/libboost_exception.a                   # [unix]
     - test -f $PREFIX/lib/libboost_test_exec_monitor.a           # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0
 
 build:
-  number: 0
+  number: 1
   skip: true            # [win and py>35]
   features:
     - vc9               # [win and py27]


### PR DESCRIPTION
Seems like the Python headers were still getting installed when they shouldn't have been. This removes them from the package. This way `boost` can be rebuilt and include them itself. Also includes the re-rendering from PR ( https://github.com/conda-forge/boost-cpp-feedstock/pull/3 ).

xref: https://github.com/conda-forge/boost-feedstock/issues/29