### PR TITLE
Fix missing include in boost::serialization

### DIFF
--- a/recipe/boost-serialization-1.64.patch
+++ b/recipe/boost-serialization-1.64.patch
@@ -1,0 +1,23 @@
+From 1d86261581230e2dc5d617a9b16287d326f3e229 Mon Sep 17 00:00:00 2001
+From: Robert Ramey <ramey@rrsd.com>
+Date: Wed, 1 Feb 2017 16:43:59 -0800
+Subject: [PATCH] correct error which appeared when compiling non c++ compliant
+ code for arrays
+
+---
+ include/boost/serialization/array.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/boost/serialization/array.hpp b/include/boost/serialization/array.hpp
+index 61708b307..612d1a619 100644
+--- a/include/boost/serialization/array.hpp
++++ b/include/boost/serialization/array.hpp
+@@ -23,6 +23,8 @@ namespace std{
+ } // namespace std
+ #endif
+ 
++#include <boost/serialization/array_wrapper.hpp>
++
+ #ifndef BOOST_NO_CXX11_HDR_ARRAY
+ 
+ #include <array>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,12 @@ source:
   fn:  {{ filename }}
   url: https://dl.bintray.com/boostorg/release/{{ version }}/source/{{ filename }}
   sha256: 7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+  patches:
+    # https://svn.boost.org/trac/boost/ticket/12516
+    - boost-serialization-1.64.patch
 
 build:
-  number: 0
+  number: 1
   skip: true            # [win and py>35]
   features:
     - vc9               # [win and py27]


### PR DESCRIPTION
* Boost ticket:
  https://svn.boost.org/trac/boost/ticket/12516
* Patch taken from upstream commit 1d86261:
  https://github.com/boostorg/serialization/commit/1d86261581230e2dc5d617a9b16287d326f3e229