### PR TITLE
Compile boost with c++14 standard

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -51,6 +51,7 @@ sed -i.bak "s,cc,${TOOLSET},g" ${SRC_DIR}/project-config.jam
     toolset=${TOOLSET}-custom \
     include="${INCLUDE_PATH}" \
     cxxflags="${CXXFLAGS}" \
+    cxxstd=14 \
     linkflags="${LINKFLAGS}" \
     --layout=system \
     -j"${CPU_COUNT}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,22 +40,40 @@ LINKFLAGS="${LINKFLAGS} -L${LIBRARY_PATH}"
 # https://stackoverflow.com/a/5244844/1005215
 sed -i.bak "s,cc,${TOOLSET},g" ${SRC_DIR}/project-config.jam
 
-./b2 -q \
-    variant=release \
-    address-model="${ARCH}" \
-    architecture=x86 \
-    debug-symbols=off \
-    threading=multi \
-    runtime-link=shared \
-    link=static,shared \
-    toolset=${TOOLSET}-custom \
-    include="${INCLUDE_PATH}" \
-    cxxflags="${CXXFLAGS}" \
-    cxxstd=14 \
-    linkflags="${LINKFLAGS}" \
-    --layout=system \
-    -j"${CPU_COUNT}" \
-    install | sed -e "s|${PREFIX}|<PREFIX>|g" | tee b2.log 2>&1
+if [[ "$cxx_compiler" == "toolchain_cxx" ]]; then
+    ./b2 -q \
+        variant=release \
+        address-model="${ARCH}" \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        runtime-link=shared \
+        link=static,shared \
+        toolset=${TOOLSET}-custom \
+        include="${INCLUDE_PATH}" \
+        cxxflags="${CXXFLAGS}" \
+        cxxstd=14 \
+        linkflags="${LINKFLAGS}" \
+        --layout=system \
+        -j"${CPU_COUNT}" \
+        install | sed -e "s|${PREFIX}|<PREFIX>|g" | tee b2.log 2>&1
+else
+    ./b2 -q \
+        variant=release \
+        address-model="${ARCH}" \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        runtime-link=shared \
+        link=static,shared \
+        toolset=${TOOLSET}-custom \
+        include="${INCLUDE_PATH}" \
+        cxxflags="${CXXFLAGS}" \
+        linkflags="${LINKFLAGS}" \
+        --layout=system \
+        -j"${CPU_COUNT}" \
+        install | sed -e "s|${PREFIX}|<PREFIX>|g" | tee b2.log 2>&1
+fi
 
 # Remove Python headers as we don't build Boost.Python.
 rm "${PREFIX}/include/boost/python.hpp"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7
 
 build:
-  number: 1000
+  number: 1001
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please add any other relevant info below:
-->

This compiles the boost libraries on mac and linux with the c++ 14 standard.
This is necessary to link to packages that are build with c++14, see
https://github.com/boostorg/system/issues/26 and should be backward compatible.

This is necessary for https://github.com/conda-forge/z5py-feedstock/pull/6.