### PR TITLE
Move cmake

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,6 +24,9 @@ rmdir /s /q %LIBRARY_INC%\boost\python
 move %LIBRARY_LIB%\boost*.dll "%LIBRARY_BIN%"
 if errorlevel 1 exit 1
 
+:: Move cmake configu files away
+ren %LIBRARY_LIB%\cmake %LIBRARY_LIB%\cmake-bak
+
 :: Set BOOST_AUTO_LINK_NOMANGLE so that auto-linking uses system layout
 echo &echo.                           >> %LIBRARY_INC%\boost\config\user.hpp
 echo #define BOOST_AUTO_LINK_NOMANGLE >> %LIBRARY_INC%\boost\config\user.hpp

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -65,3 +65,6 @@ fi
 # Remove Python headers as we don't build Boost.Python.
 rm "${PREFIX}/include/boost/python.hpp"
 rm -r "${PREFIX}/include/boost/python"
+
+# Move the cmake directory in $PREFIX
+mv "${PREFIX}/lib/cmake" "${PREFIX}/lib/cmake-bak"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This pull request addresses issue #61 where the installed boost cmake config files were inhibiting the ability to link with the shared libraries of a dependent project. This change moves the ```[$PREFIX/lib,%LIBRARY_LIB]/cmake``` directory to ```cmake-bak```.