### PR TITLE
Fix build of boost::iostreams zlib filter

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -19,9 +19,13 @@ pin_run_as_build:
     max_pin: x
   xz:
     max_pin: x.x
+  zlib:
+    max_pin: x.x
 target_platform:
 - linux-64
 xz:
 - '5.2'
+zlib:
+- '1.2'
 zstd:
 - '1.5'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -23,9 +23,13 @@ pin_run_as_build:
     max_pin: x
   xz:
     max_pin: x.x
+  zlib:
+    max_pin: x.x
 target_platform:
 - linux-aarch64
 xz:
 - '5.2'
+zlib:
+- '1.2'
 zstd:
 - '1.5'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -19,9 +19,13 @@ pin_run_as_build:
     max_pin: x
   xz:
     max_pin: x.x
+  zlib:
+    max_pin: x.x
 target_platform:
 - linux-ppc64le
 xz:
 - '5.2'
+zlib:
+- '1.2'
 zstd:
 - '1.5'

--- a/.ci_support/migrations/icu69.yaml
+++ b/.ci_support/migrations/icu69.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-icu:
-- '69'
-migrator_ts: 1635419000.7351162

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,9 +19,13 @@ pin_run_as_build:
     max_pin: x
   xz:
     max_pin: x.x
+  zlib:
+    max_pin: x.x
 target_platform:
 - osx-64
 xz:
 - '5.2'
+zlib:
+- '1.2'
 zstd:
 - '1.5'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,9 +19,13 @@ pin_run_as_build:
     max_pin: x
   xz:
     max_pin: x.x
+  zlib:
+    max_pin: x.x
 target_platform:
 - osx-arm64
 xz:
 - '5.2'
+zlib:
+- '1.2'
 zstd:
 - '1.5'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,7 +9,11 @@ cxx_compiler:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  zlib:
+    max_pin: x.x
 target_platform:
 - win-64
+zlib:
+- '1.2'
 zstd:
 - '1.5'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - e193f080c7d209516ac9b712fa0c50bb08026fa2.patch
 
 build:
-  number: 6
+  number: 7
 
 requirements:
   build:
@@ -24,6 +24,7 @@ requirements:
     - icu               # [unix]
     - xz                # [unix]
     - bzip2
+    - zlib
     - zstd
 
   run:
@@ -36,6 +37,8 @@ requirements:
     - libboost <0
 
 test:
+  files:
+    - test
   commands:
     # Verify Python headers are removed.
     - "! test -f $PREFIX/include/boost/python.hpp"                      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
   files:
     - test
   requires:
-    - {{ compiler('cxx') }}
+    - {{ compiler('cxx') }}    # [build_platform == target_platform]
   commands:
     # Verify Python headers are removed.
     - "! test -f $PREFIX/include/boost/python.hpp"                      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,8 @@ requirements:
 test:
   files:
     - test
+  requires:
+    - {{ compiler('cxx') }}
   commands:
     # Verify Python headers are removed.
     - "! test -f $PREFIX/include/boost/python.hpp"                      # [unix]

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,4 @@
+:: Test boost::iostreams zlib filter support
+cd test
+cl.exe /EHsc /I%PREFIX%\Library\include test_iostreams_zlib.cpp /link /libpath:%PREFIX%\Library\lib boost_iostreams.lib
+if errorlevel 1 exit 1

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,4 +1,4 @@
 :: Test boost::iostreams zlib filter support
 cd test
-cl.exe /EHsc /I%PREFIX%\Library\include test_iostreams_zlib.cpp /link /libpath:%PREFIX%\Library\lib boost_iostreams.lib
+cl.exe /EHsc /MD /DBOOST_ALL_DYN_LINK /DBOOST_ZLIB_BINARY=kernel32 /I%PREFIX%\Library\include test_iostreams_zlib.cpp /link /libpath:%PREFIX%\Library\lib
 if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,5 @@
 # Skip compile tests if we are cross-compiling
-if echo ${CONDA_TOOLCHAIN_HOST} | grep -q arm64-apple; then
+if [[ "${build_platform}" != "${target_platform}" ]]; then
   exit 0
 fi
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,5 @@
 # Skip compile tests if we are cross-compiling
-if [ "${BUILD_PLATFORM}" != "${HOST_PLATFORM}" ]; then
+if echo ${CONDA_TOOLCHAIN_HOST} | grep -q arm64-apple; then
   exit 0
 fi
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,3 @@
+# Test boost::iostreams zlib filter support
+cd test
+${CXX} -I$PREFIX/include -L$PREFIX/lib test_iostreams_zlib.cpp -lboost_iostreams

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,5 @@
 # Skip compile tests if we are cross-compiling
-if [ "${CONDA_BUILD_CROSS_COMPILATION}" = "1" ]; then
+if [ "${BUILD_PLATFORM}" != "${HOST_PLATFORM}" ]; then
   exit 0
 fi
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,3 +1,8 @@
+# Skip compile tests if we are cross-compiling
+if [ "${CONDA_BUILD_CROSS_COMPILATION}" = "1" ]; then
+  exit 0
+fi
+
 # Test boost::iostreams zlib filter support
 cd test
 ${CXX} -I$PREFIX/include -L$PREFIX/lib test_iostreams_zlib.cpp -lboost_iostreams

--- a/recipe/test/test_iostreams_zlib.cpp
+++ b/recipe/test/test_iostreams_zlib.cpp
@@ -1,0 +1,19 @@
+// Ensure that boost::iostreams includes the zlib filter support
+
+#include <fstream>
+#include <iostream>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+
+int main()
+{
+    using namespace std;
+
+    ifstream file("hello.z", ios_base::in | ios_base::binary);
+    boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
+    in.push(boost::iostreams::zlib_decompressor());
+    in.push(file);
+    boost::iostreams::copy(in, cout);
+    return 0;
+}


### PR DESCRIPTION
Explicitly add zlib to the requirements so that
boost::iostreams gets built with the zlib filter.
This was being pulled in implicitly at one point
but recently stopped working; make it explicit.
Add a compile+link test to make sure the final
library includes the necessary symbols. Closes #114.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
