### PR TITLE
Rebuild 1.80 with newer compilers & enable 1.78 migrations

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,17 +14,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 icu:
 - '70'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  xz:
-    max_pin: x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-64
 xz:
-- '5.2'
+- '5'
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -18,17 +18,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 icu:
 - '70'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  xz:
-    max_pin: x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-aarch64
 xz:
-- '5.2'
+- '5'
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -14,17 +14,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 icu:
 - '70'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  xz:
-    max_pin: x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-ppc64le
 xz:
-- '5.2'
+- '5'
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/migrations/icu70.yaml
+++ b/.ci_support/migrations/icu70.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-icu:
-- '70'
-migrator_ts: 1648069834.8412466

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -9,22 +9,15 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '14'
 icu:
 - '70'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  xz:
-    max_pin: x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-64
 xz:
-- '5.2'
+- '5'
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -9,22 +9,15 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '14'
 icu:
 - '70'
 macos_machine:
 - arm64-apple-darwin20.0.0
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  xz:
-    max_pin: x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-arm64
 xz:
-- '5.2'
+- '5'
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,12 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  zlib:
-    max_pin: x.x
+- vs2019
 target_platform:
 - win-64
 zlib:

--- a/README.md
+++ b/README.md
@@ -205,3 +205,6 @@ Feedstock Maintainers
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@xhochy](https://github.com/xhochy/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/README.md
+++ b/README.md
@@ -205,6 +205,3 @@ Feedstock Maintainers
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@xhochy](https://github.com/xhochy/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 bot:
   abi_migration_branches:
-  - 1.72.x
-  - 1.74.x
+  - 1.78.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 5864f397.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in conda-forge/boost-cpp-feedstock#128.


Here's a checklist to do before merging.
- [x] Bump the build number if needed.

Fixes https://github.com/conda-forge/boost-feedstock/issues/169